### PR TITLE
Add JS Bundle Size browser extenstion

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@
   - [25 Essential Chrome Extensions for Web Designers](https://envato.com/blog/chrome-extensions-web-design/)
   - [Checkbot](https://www.checkbot.io/) - crawls your site testing pages follow 50+ SEO, speed and security best practices.
   - [CSS Peeper](https://csspeeper.com/) - Smart CSS viewer tailored for Designers.
+  - [JS Bundle Size](https://github.com/vicrazumov/js-bundle-size) - Automatically adds javascript bundle size data to npm and github project pages.
 
 ### Benchmark <a name="benchmark"></a> [&#x2191;&nbsp;&#x2191;&nbsp;&#x2191;](#toc)
 * [CSS minification benchmark](http://goalsmashers.github.io/css-minification-benchmark/)


### PR DESCRIPTION
Hi @gamtiq,

Thanks for the great selection of tools. I've added a link to my cross-browser extension, that automatically fetches bundle size data from bundlephobia and adds it to the github and npm pages.

![image](https://user-images.githubusercontent.com/4419866/52179328-61943480-27d9-11e9-878a-be0161169e6a.png)
![image](https://user-images.githubusercontent.com/4419866/52179331-6527bb80-27d9-11e9-8818-0e2e67018262.png)
